### PR TITLE
Fix cljsbuild source map path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,5 +32,5 @@
                                    :asset-path "js/out"
                                    :optimizations :advanced
                                    :main agglo.core
-                                   :source-map true}}]}
+                                   :source-map "resources/public/js/main.js.map"}}]}
   :main agglo.core)


### PR DESCRIPTION
## Summary
- set explicit source map file path for cljsbuild compiler

## Testing
- `lein cljsbuild once`
